### PR TITLE
Corrections: document language & configure timezone of app (Paris)

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -33,7 +33,7 @@ class Document < ApplicationRecord
   }
 
   validates :title, presence: true
-  validates :language, presence: true, inclusion: { in: LANGUAGES.keys }
+  validates :language, presence: true, inclusion: { in: LANGUAGES.stringify_keys.keys }
   validates :attachment, presence: true
 
   scope :validated, -> { where.not(validation_at: nil) }

--- a/app/views/admin/documents/_form.slim
+++ b/app/views/admin/documents/_form.slim
@@ -1,6 +1,6 @@
 = simple_form_for [:admin, @document], remote: true do |f|
   = f.input :title
-  = f.input :language, as: :radio_buttons, collection: Document::LANGUAGES
+  = f.input :language, as: :radio_buttons, collection: Document::LANGUAGES.map { |k,v| [v,k] }
   = f.input :usage
   = f.input :attachment, as: :file
   .text-center = f.submit class: "btn"

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -61,4 +61,6 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  config.active_record.default_timezone = 'Paris'
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -111,4 +111,5 @@ Rails.application.configure do
   # config.active_record.database_selector = { delay: 2.seconds }
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+  config.active_record.default_timezone = 'Paris'
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -111,4 +111,5 @@ Rails.application.configure do
   # config.active_record.database_selector = { delay: 2.seconds }
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+  config.active_record.default_timezone = 'Paris'
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -46,4 +46,5 @@ Rails.application.configure do
 
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
+  config.active_record.default_timezone = 'Paris'
 end


### PR DESCRIPTION
- correct languages for documents in model and in view
- configure timezone Paris in each environment because search on date was not good