### PR TITLE
get local time for documents/created_at

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -62,5 +62,6 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
-  config.active_record.default_timezone = 'Paris'
+  config.time_zone = "Paris"
+  config.active_record.default_timezone = :local
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -111,5 +111,6 @@ Rails.application.configure do
   # config.active_record.database_selector = { delay: 2.seconds }
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
-  config.active_record.default_timezone = 'Paris'
+  config.time_zone = "Paris"
+  config.active_record.default_timezone = :local
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -46,5 +46,6 @@ Rails.application.configure do
 
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
-  config.active_record.default_timezone = 'Paris'
+  config.time_zone = "Paris"
+  config.active_record.default_timezone = :local
 end


### PR DESCRIPTION
update prod/test/dev configurations to get local time for documents/created_at