### PR TITLE
Add fields to shared lists

### DIFF
--- a/app/assets/stylesheets/components/_forms.scss
+++ b/app/assets/stylesheets/components/_forms.scss
@@ -17,7 +17,7 @@
   }
 }
 
-.simple_form.label-input-in-line {
+.simple_form.label-input-in-line, .simple_form.label-input-in-line-equal-space {
   label {
     margin-bottom: 0;
     display: flex;
@@ -25,7 +25,7 @@
   }
   .form-group {
     display: grid;
-    grid-template-columns: 1fr 4fr;
+    grid-template-columns: 1fr 1fr;
     .disabled {
       background: none;
       border: none;
@@ -33,5 +33,17 @@
   }
   .form-group.disabled {
     padding-right: 0;
+  }
+}
+
+.simple_form.label-input-in-line {
+  .form-group {
+    grid-template-columns: 1fr 4fr;
+  }
+}
+
+.simple_form.label-input-in-line-equal-space {
+  .form-group {
+    grid-template-columns: 1fr 1fr;
   }
 }

--- a/app/controllers/shared_lists_controller.rb
+++ b/app/controllers/shared_lists_controller.rb
@@ -13,7 +13,6 @@ class SharedListsController < ApplicationController
 
   def create_and_attach_document
     @shared_document = @shared_list.shared_documents.new(document: @document)
-    @shared_list.code = SecureRandom.alphanumeric(16)
     if @shared_list.save
       redirect_to document_path(@document), flash: { validation_message: true, message: "Votre liste de partage a bien été créée et votre document a bien été ajouté." }
     else
@@ -69,6 +68,7 @@ class SharedListsController < ApplicationController
   def new_shared_list
     @shared_list = current_user.shared_lists.new(shared_list_params)
     authorize @shared_list
+    @shared_list.code = SecureRandom.alphanumeric(16)
   end
 
   def find_folder

--- a/app/controllers/shared_lists_controller.rb
+++ b/app/controllers/shared_lists_controller.rb
@@ -13,6 +13,7 @@ class SharedListsController < ApplicationController
 
   def create_and_attach_document
     @shared_document = @shared_list.shared_documents.new(document: @document)
+    @shared_list.code = SecureRandom.alphanumeric(16)
     if @shared_list.save
       redirect_to document_path(@document), flash: { validation_message: true, message: "Votre liste de partage a bien été créée et votre document a bien été ajouté." }
     else
@@ -83,6 +84,6 @@ class SharedListsController < ApplicationController
   end
 
   def shared_list_params
-    params.require(:shared_list).permit(:title)
+    params.require(:shared_list).permit(:title, :validity, :download)
   end
 end

--- a/app/javascript/controllers/flatpickr_controller.js
+++ b/app/javascript/controllers/flatpickr_controller.js
@@ -1,0 +1,19 @@
+import { Controller } from 'stimulus';
+import flatpickr from 'plugins/flatpickr/flatpickr';
+
+export default class extends Controller {
+  static targets = [
+    'dateSelection'
+  ]
+
+  connect() {
+    flatpickr(this.dateSelectionTarget, {
+      // locale: "fr", # replace by flatpickr.localize(French)
+      // mode: "range",
+      minDate: 'today',
+      altInput: true,
+      altFormat: "D j F Y",
+      dateFormat: "Y-m-d"
+    });
+  }
+}

--- a/app/models/shared_list.rb
+++ b/app/models/shared_list.rb
@@ -9,6 +9,7 @@ class SharedList < ApplicationRecord
   has_many :contacts
 
   validates :title, presence: true, uniqueness: { scope: :user }
+  validates :code, presence: true, uniqueness: true, length: { is: 16 }
 
   scope :ordered_by_title, -> { order('lower(title)') }
 end

--- a/app/views/documents/_add_to_folder_form.slim
+++ b/app/views/documents/_add_to_folder_form.slim
@@ -1,6 +1,6 @@
 = simple_form_for [:admin, document], url: add_to_folder_admin_document_path(document), remote: true do |f|
   .mb-3
-    = f.association :folders, as: :check_boxes, label: "Dossier(s)"
+    = f.association :folders, as: :check_boxes, legend_tag: false
   .mb-3
     p.mb-2 et/ou Nouveau dossier
     = f.fields_for :folders, document.folders.build do |folders_fields|

--- a/app/views/documents/_add_to_shared_list_or_folder_modal.html.erb
+++ b/app/views/documents/_add_to_shared_list_or_folder_modal.html.erb
@@ -10,12 +10,20 @@
       </div>
       <div class="modal-body">
         <% if policy(shared_document).create? %>
+          <p class="mb-2">Liste de partage</p>
           <%= render 'shared_documents/form', document: document, shared_document: shared_document %>
         <% end %>
         <% if policy(shared_list).create_and_attach_document? %>
+          <p class="mb-2">Liste de partage</p>
+          <% if shared_list.errors.messages[:code].present? %>
+            <p class="alert-warning p-3">
+              Une erreur s'est produite dans la génération du code associé à la liste de partage. Veuillez valider à nouveau votre saisie.
+            </p>
+          <% end %>
           <%= render 'shared_lists/create_and_attach_document_form', document: document, shared_list: shared_list %>
         <% end %>
         <% if policy([:admin, document]).add_to_folder? %>
+          <p class="mb-2">Dossier(s)</p>
           <%= render 'documents/add_to_folder_form', document: document %>
         <% end %>
         <!-- TO KEEP: initial version to add folders or documents to shared list directly -->

--- a/app/views/folders/_add_to_shared_list_modal.html.erb
+++ b/app/views/folders/_add_to_shared_list_modal.html.erb
@@ -9,6 +9,7 @@
         </button>
       </div>
       <div class="modal-body">
+        <p class="mb-2">Liste de partage</p>
         <% if policy(shared_folder).create? %>
           <%= render 'shared_folders/form', folder: folder, shared_folder: shared_folder %>
         <% end %>

--- a/app/views/folders/_card.slim
+++ b/app/views/folders/_card.slim
@@ -9,6 +9,6 @@
         i.fa.fa-search
       = link_to download_folder_path(folder), method: :patch, class: "btn" do
         i.fas.fa-file-download
-      - if params[:controller] == "folders" && params[:action] == "index"
+      - if (params[:controller] == "folders" && params[:action] == "index") || (params[:controller] == "shared_lists" && params[:action] == "create_and_attach_folder")
         = link_to folder_path(folder), data: { toggle: "modal", target: "#addFolder#{folder.id}ToSharedList" }, class: "btn" do
           i.fas.fa-plus

--- a/app/views/shared_documents/_form.slim
+++ b/app/views/shared_documents/_form.slim
@@ -1,3 +1,3 @@
 = simple_form_for [document, shared_document], remote: true do |f|
-  = f.association :shared_list, collection: current_user.shared_lists.initial, as: :radio_buttons, required: false
-  = f.submit "Valider", class: "btn"
+  = f.association :shared_list, collection: current_user.shared_lists.initial, as: :radio_buttons, required: false, legend_tag: false
+  .text-right = f.submit "Valider", class: "btn"

--- a/app/views/shared_folders/_form.slim
+++ b/app/views/shared_folders/_form.slim
@@ -1,3 +1,3 @@
 = simple_form_for [folder, shared_folder], remote: true do |f|
-  = f.association :shared_list, collection: current_user.shared_lists.initial, as: :radio_buttons, required: false
+  = f.association :shared_list, collection: current_user.shared_lists.initial, as: :radio_buttons, required: false, legend_tag: false
   = f.submit "Valider", class: "btn"

--- a/app/views/shared_lists/_create_and_attach_document_form.html.erb
+++ b/app/views/shared_lists/_create_and_attach_document_form.html.erb
@@ -1,5 +1,5 @@
-<%= simple_form_for [document, shared_list], url: create_and_attach_document_document_shared_lists_path(document), data: { controller: "flatpickr" }, html: { class: "label-input-in-line-equal-space" } do |f| %>
-  <%= f.input :title %>
+<%= simple_form_for [document, shared_list], url: create_and_attach_document_document_shared_lists_path(document), data: { controller: "flatpickr" }, html: { class: "label-input-in-line-equal-space" }, remote: true do |f| %>
+  <%= f.input :title, label: false, placeholder: "Nommez votre liste de partage", input_html: { style: "grid-column: 1 / span 2" } %>
   <%= f.input :validity, as: :string, placeholder: "Date", input_html: { data: { target: "flatpickr.dateSelection" } } %>
   <%= f.input :download, as: :select, include_blank: false %>
   <div class="text-right">

--- a/app/views/shared_lists/_create_and_attach_document_form.html.erb
+++ b/app/views/shared_lists/_create_and_attach_document_form.html.erb
@@ -1,0 +1,10 @@
+<%= simple_form_for [document, shared_list], url: create_and_attach_document_document_shared_lists_path(document), data: { controller: "flatpickr" }, html: { class: "label-input-in-line-equal-space" } do |f| %>
+  <%= f.input :title %>
+  <%= f.input :validity, as: :string, placeholder: "Date", input_html: { data: { target: "flatpickr.dateSelection" } } %>
+  <%= f.input :download, as: :select, include_blank: false %>
+  <div class="text-right">
+    <%= f.submit "Valider", class: "btn" %>
+  </div>
+<% end %>
+
+

--- a/app/views/shared_lists/_create_and_attach_document_form.slim
+++ b/app/views/shared_lists/_create_and_attach_document_form.slim
@@ -1,3 +1,0 @@
-= simple_form_for [document, shared_list], url: create_and_attach_document_document_shared_lists_path(document), remote: true do |f|
-  = f.input :title
-  = f.submit "Valider", class: "btn"

--- a/app/views/shared_lists/_create_and_attach_folder_form.slim
+++ b/app/views/shared_lists/_create_and_attach_folder_form.slim
@@ -1,3 +1,5 @@
-= simple_form_for [folder, shared_list], url: create_and_attach_folder_folder_shared_lists_path(folder), remote: true do |f|
-  = f.input :title
-  = f.submit "Valider", class: "btn"
+= simple_form_for [folder, shared_list], url: create_and_attach_folder_folder_shared_lists_path(folder), data: { controller: "flatpickr" }, html: { class: "label-input-in-line-equal-space" }, remote: true do |f|
+  = f.input :title, label: false, placeholder: "Nommez votre liste de partage", input_html: { style: "grid-column: 1 / span 2" }
+  = f.input :validity, as: :string, placeholder: "Date", input_html: { data: { target: "flatpickr.dateSelection" } }
+  = f.input :download, as: :select, include_blank: false
+  text-right = f.submit "Valider", class: "btn"

--- a/config/locales/activerecord.fr.yml
+++ b/config/locales/activerecord.fr.yml
@@ -15,6 +15,8 @@ fr:
         email: E-mail
       shared_list:
         title: Titre
+        validity: Jusqu'au
+        download: Téléchargeable
       shared_document:
         shared_list: Liste de partage
         document: Document

--- a/config/locales/simple_form.fr.yml
+++ b/config/locales/simple_form.fr.yml
@@ -1,0 +1,31 @@
+fr:
+  simple_form:
+    "yes": 'Oui'
+    "no": 'Non'
+    required:
+      text: 'Requis'
+      mark: '*'
+      # You can uncomment the line below if you need to overwrite the whole required html.
+      # When using html, text and mark won't be used.
+      # html: '<abbr title="required">*</abbr>'
+    error_notification:
+      default_message: "Veuillez corriger les problèmes ci-dessous:"
+    # Examples
+    # labels:
+    #   defaults:
+    #     password: 'Password'
+    #   user:
+    #     new:
+    #       email: 'E-mail to sign in.'
+    #     edit:
+    #       email: 'E-mail.'
+    # hints:
+    #   defaults:
+    #     username: 'User name to sign in.'
+    #     password: 'No special characters, please.'
+    # include_blanks:
+    #   defaults:
+    #     age: 'Rather not say'
+    # prompts:
+    #   defaults:
+    #     age: 'Select your age'

--- a/db/migrate/20210208220633_add_validity_download_code_to_shared_lists.rb
+++ b/db/migrate/20210208220633_add_validity_download_code_to_shared_lists.rb
@@ -1,0 +1,7 @@
+class AddValidityDownloadCodeToSharedLists < ActiveRecord::Migration[6.0]
+  def change
+    add_column :shared_lists, :validity, :date
+    add_column :shared_lists, :download, :boolean
+    add_column :shared_lists, :code, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_05_105241) do
+ActiveRecord::Schema.define(version: 2021_02_08_220633) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -103,6 +103,9 @@ ActiveRecord::Schema.define(version: 2021_02_05_105241) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "aasm_state"
+    t.date "validity"
+    t.boolean "download"
+    t.string "code"
     t.index ["user_id"], name: "index_shared_lists_on_user_id"
   end
 


### PR DESCRIPTION
- add validity, code, download fields to shared_lists
- set these fields as inputs in shared_list creation forms
- update shared_lists controller to use these fields
- add flatpickr_controller.js for validity input to display as calendar

OTHER
- add translation file for simple_form_for