### PR TITLE
Rename shared document in document shared list version two

### DIFF
--- a/app/controllers/document_shared_lists_controller.rb
+++ b/app/controllers/document_shared_lists_controller.rb
@@ -1,10 +1,10 @@
-class SharedDocumentsController < ApplicationController
+class DocumentSharedListsController < ApplicationController
   def create
     @shared_list = SharedList.new
     @document = Document.find(params[:document_id]).decorate
-    @shared_document = @document.shared_documents.new(shared_document_params)
-    authorize @shared_document
-    if @shared_document.save
+    @document_shared_list = @document.document_shared_lists.new(document_shared_list_params)
+    authorize @document_shared_list
+    if @document_shared_list.save
       redirect_to document_path(@document), flash: { validation_message: true, message: "Votre document a bien été ajouté à la liste de partage." }
     else
       flash.now[:errors_attach_document] = true
@@ -12,7 +12,7 @@ class SharedDocumentsController < ApplicationController
     end
   end
 
-  def shared_document_params
-    params.require(:shared_document).permit(:shared_list_id)
+  def document_shared_list_params
+    params.require(:document_shared_list).permit(:shared_list_id)
   end
 end

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -3,7 +3,7 @@ class DocumentsController < ApplicationController
 
   def show
     @shared_list = SharedList.new
-    @shared_document = SharedDocument.new
+    @document_shared_list = DocumentSharedList.new
   end
 
   def index

--- a/app/controllers/shared_lists_controller.rb
+++ b/app/controllers/shared_lists_controller.rb
@@ -12,7 +12,7 @@ class SharedListsController < ApplicationController
   end
 
   def create_and_attach_document
-    @shared_document = @shared_list.shared_documents.new(document: @document)
+    @document_shared_list = @shared_list.document_shared_lists.new(document: @document)
     if @shared_list.save
       redirect_to document_path(@document), flash: { validation_message: true, message: "Votre liste de partage a bien été créée et votre document a bien été ajouté." }
     else

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -5,8 +5,8 @@ class Document < ApplicationRecord
   has_one_attached :attachment
   has_many :document_folders
   has_many :folders, through: :document_folders
-  has_many :shared_documents
-  has_many :shared_lists, through: :shared_documents
+  has_many :document_shared_lists
+  has_many :shared_lists, through: :document_shared_lists
 
   # accepts_nested_attributes_for :folders, reject_if: -> (folder) { folder[:title].blank? }
   ## do the same thing

--- a/app/models/document_shared_list.rb
+++ b/app/models/document_shared_list.rb
@@ -1,4 +1,4 @@
-class SharedDocument < ApplicationRecord
+class DocumentSharedList < ApplicationRecord
   belongs_to :shared_list
   belongs_to :document
 

--- a/app/models/shared_list.rb
+++ b/app/models/shared_list.rb
@@ -2,8 +2,8 @@ class SharedList < ApplicationRecord
   include SharedListStateMachine
 
   belongs_to :user
-  has_many :shared_documents
-  has_many :documents, through: :shared_documents
+  has_many :document_shared_lists
+  has_many :documents, through: :document_shared_lists
   has_many :shared_folders
   has_many :folders, through: :shared_folders
   has_many :contacts

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :recoverable, :rememberable, :validatable, :password_expirable, :password_archivable
 
   has_many :shared_lists
-  has_many :shared_documents, through: :shared_lists
+  has_many :document_shared_lists, through: :shared_lists
   has_many :shared_folders, through: :shared_lists
 
   validates :first_name, presence: true

--- a/app/policies/document_shared_list_policy.rb
+++ b/app/policies/document_shared_list_policy.rb
@@ -1,4 +1,4 @@
-class SharedDocumentPolicy < ApplicationPolicy
+class DocumentSharedListPolicy < ApplicationPolicy
   def create?
     user.shared_lists.initial.present?
   end

--- a/app/views/document_shared_lists/_form.slim
+++ b/app/views/document_shared_lists/_form.slim
@@ -1,3 +1,3 @@
-= simple_form_for [document, shared_document], remote: true do |f|
+= simple_form_for [document, document_shared_list], remote: true do |f|
   = f.association :shared_list, collection: current_user.shared_lists.initial, as: :radio_buttons, required: false, legend_tag: false
   .text-right = f.submit "Valider", class: "btn"

--- a/app/views/documents/_add_to_shared_list_or_folder_modal.html.erb
+++ b/app/views/documents/_add_to_shared_list_or_folder_modal.html.erb
@@ -9,9 +9,9 @@
         </button>
       </div>
       <div class="modal-body">
-        <% if policy(shared_document).create? %>
+        <% if policy(document_shared_list).create? %>
           <p class="mb-2">Liste de partage</p>
-          <%= render 'shared_documents/form', document: document, shared_document: shared_document %>
+          <%= render 'document_shared_lists/form', document: document, document_shared_list: document_shared_list %>
         <% end %>
         <% if policy(shared_list).create_and_attach_document? %>
           <p class="mb-2">Liste de partage</p>

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -2,4 +2,4 @@
   <%= render "documents/show_content", document: @document %>
 </div>
 
-<%= render 'documents/add_to_shared_list_or_folder_modal', document: @document, shared_list: @shared_list, shared_document: @shared_document %>
+<%= render 'documents/add_to_shared_list_or_folder_modal', document: @document, shared_list: @shared_list, document_shared_list: @document_shared_list %>

--- a/app/views/shared/_flashes.html.erb
+++ b/app/views/shared/_flashes.html.erb
@@ -24,7 +24,7 @@
 
 <% if flash[:errors_attach_document] %>
   <div data-controller = "show-modal">
-    <%= render 'documents/add_to_shared_list_or_folder_modal', document: @document, shared_list: @shared_list, shared_document: @shared_document %>
+    <%= render 'documents/add_to_shared_list_or_folder_modal', document: @document, shared_list: @shared_list, document_shared_list: @document_shared_list %>
   </div>
 <% end %>
 

--- a/config/locales/activerecord.fr.yml
+++ b/config/locales/activerecord.fr.yml
@@ -17,7 +17,7 @@ fr:
         title: Titre
         validity: Jusqu'au
         download: Téléchargeable
-      shared_document:
+      document_shared_list:
         shared_list: Liste de partage
         document: Document
       shared_folder:
@@ -26,7 +26,7 @@ fr:
 
     errors:
       models:
-        shared_document:
+        document_shared_list:
           taken: contient déjà ce document
         shared_folder:
           taken: contient déjà ce dossier

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
     resources :shared_lists do
       post :create_and_attach_document, on: :collection
     end
-    resources :shared_documents, only: %i[create]
+    resources :document_shared_lists, only: %i[create]
   end
   resources :folders, only: %i[index show] do
     patch :download, on: :member

--- a/db/migrate/20210210131522_create_document_shared_lists.rb
+++ b/db/migrate/20210210131522_create_document_shared_lists.rb
@@ -1,6 +1,6 @@
-class CreateSharedDocuments < ActiveRecord::Migration[6.0]
+class CreateDocumentSharedLists < ActiveRecord::Migration[6.0]
   def change
-    create_table :shared_documents do |t|
+    create_table :document_shared_lists do |t|
       t.references :shared_list, null: false, foreign_key: true
       t.references :document, null: false, foreign_key: true
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_08_220633) do
+ActiveRecord::Schema.define(version: 2021_02_10_131522) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -54,6 +54,15 @@ ActiveRecord::Schema.define(version: 2021_02_08_220633) do
     t.index ["folder_id"], name: "index_document_folders_on_folder_id"
   end
 
+  create_table "document_shared_lists", force: :cascade do |t|
+    t.bigint "shared_list_id", null: false
+    t.bigint "document_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["document_id"], name: "index_document_shared_lists_on_document_id"
+    t.index ["shared_list_id"], name: "index_document_shared_lists_on_shared_list_id"
+  end
+
   create_table "documents", force: :cascade do |t|
     t.string "title"
     t.string "language"
@@ -77,15 +86,6 @@ ActiveRecord::Schema.define(version: 2021_02_08_220633) do
     t.string "password_salt"
     t.datetime "created_at"
     t.index ["password_archivable_type", "password_archivable_id"], name: "index_password_archivable"
-  end
-
-  create_table "shared_documents", force: :cascade do |t|
-    t.bigint "shared_list_id", null: false
-    t.bigint "document_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["document_id"], name: "index_shared_documents_on_document_id"
-    t.index ["shared_list_id"], name: "index_shared_documents_on_shared_list_id"
   end
 
   create_table "shared_folders", force: :cascade do |t|
@@ -130,8 +130,8 @@ ActiveRecord::Schema.define(version: 2021_02_08_220633) do
   add_foreign_key "contacts", "shared_lists"
   add_foreign_key "document_folders", "documents"
   add_foreign_key "document_folders", "folders"
-  add_foreign_key "shared_documents", "documents"
-  add_foreign_key "shared_documents", "shared_lists"
+  add_foreign_key "document_shared_lists", "documents"
+  add_foreign_key "document_shared_lists", "shared_lists"
   add_foreign_key "shared_folders", "folders"
   add_foreign_key "shared_folders", "shared_lists"
   add_foreign_key "shared_lists", "users"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,6 +1,6 @@
 puts 'Destroying'
 Contact.destroy_all
-SharedDocument.destroy_all
+DocumentSharedList.destroy_all
 SharedFolder.destroy_all
 SharedList.destroy_all
 # User.destroy_all

--- a/spec/factories/document_shared_lists.rb
+++ b/spec/factories/document_shared_lists.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :shared_document do
+  factory :document_shared_list do
     shared_list { nil }
     document { nil }
   end

--- a/spec/models/document_shared_list_spec.rb
+++ b/spec/models/document_shared_list_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
-RSpec.describe SharedDocument, type: :model do
+RSpec.describe DocumentSharedList, type: :model do
   pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/policies/document_shared_list_policy_spec.rb
+++ b/spec/policies/document_shared_list_policy_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe SharedDocumentPolicy, type: :policy do
+RSpec.describe DocumentSharedListPolicy, type: :policy do
   let(:user) { User.new }
 
   subject { described_class }

--- a/spec/requests/document_shared_lists_request_spec.rb
+++ b/spec/requests/document_shared_lists_request_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "DocumentSharedLists", type: :request do
+
+end

--- a/spec/requests/shared_documents_request_spec.rb
+++ b/spec/requests/shared_documents_request_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe "SharedDocuments", type: :request do
-
-end


### PR DESCRIPTION
- remove table shared_documents and replace it by document_shared_lists
- rename shared_document(s) in document_shared_list(s) in folders / files name / files content