### PR TITLE
errors-on-migration-files-solving

### DIFF
--- a/db/migrate/20210210174417_drop_table_document_shared_lists.rb
+++ b/db/migrate/20210210174417_drop_table_document_shared_lists.rb
@@ -1,5 +1,0 @@
-class DropTableDocumentSharedLists < ActiveRecord::Migration[6.0]
-  def change
-    drop_table :document_shared_lists
-  end
-end

--- a/db/migrate/20210210184124_drop_folder_shared_lists_table.rb
+++ b/db/migrate/20210210184124_drop_folder_shared_lists_table.rb
@@ -1,5 +1,0 @@
-class DropFolderSharedListsTable < ActiveRecord::Migration[6.0]
-  def change
-    drop_table :folder_shared_lists
-  end
-end


### PR DESCRIPTION
remove migration for drop_table_document_shared_lists and drop_folder_shared_lists_table