### PR TITLE
Documents index allow share and send from cards

### DIFF
--- a/app/assets/stylesheets/override/bootstrap/_reboot.scss
+++ b/app/assets/stylesheets/override/bootstrap/_reboot.scss
@@ -9,3 +9,7 @@ abbr[title], abbr[data-original-title] {
 //   -webkit-text-decoration-skip-ink: none;
 //           text-decoration-skip-ink: none;
 }
+
+button:focus {
+  outline: none;
+}

--- a/app/controllers/admin/documents_controller.rb
+++ b/app/controllers/admin/documents_controller.rb
@@ -5,7 +5,7 @@ class Admin::DocumentsController < ApplicationController
   def validate
     @document.validation_at = DateTime.now
     if @document.save
-      redirect_to documents_path
+      redirect_to document_path(@document)
     else
       render "documents/show"
     end
@@ -39,7 +39,10 @@ class Admin::DocumentsController < ApplicationController
 
   def add_to_folder
     if @document.update(folder_params)
-      redirect_to document_path(@document), flash: { validation_message: true, message: "Votre document a bien été ajouté au dossier." }
+      respond_to do |format|
+        format.html { redirect_to document_path(@document), flash: { validation_message: true, message: "Votre document a bien été ajouté au(x) dossier(s)." } }
+        format.js { @message = "Votre document a bien été ajouté au(x) dossier(s)." }
+      end
     else
       render :show
     end

--- a/app/controllers/admin/documents_controller.rb
+++ b/app/controllers/admin/documents_controller.rb
@@ -39,7 +39,7 @@ class Admin::DocumentsController < ApplicationController
 
   def add_to_folder
     if @document.update(folder_params)
-      redirect_to document_path(@document)
+      redirect_to document_path(@document), flash: { validation_message: true, message: "Votre document a bien été ajouté au dossier." }
     else
       render :show
     end

--- a/app/controllers/document_shared_lists_controller.rb
+++ b/app/controllers/document_shared_lists_controller.rb
@@ -7,7 +7,10 @@ class DocumentSharedListsController < ApplicationController
     @document_shared_list = @document.document_shared_lists.new(document_shared_list_params)
     authorize @document_shared_list
     if @document_shared_list.save
-      redirect_to document_path(@document), flash: { validation_message: true, message: "Votre document a bien été ajouté à la liste de partage." }
+      respond_to do |format|
+        format.html { redirect_to document_path(@document), flash: { validation_message: true, message: "Votre document a bien été ajouté à la liste de partage." } }
+        format.js { @message = "Votre document a bien été ajouté à la liste de partage." }
+      end
     else
       flash.now[:errors_attach_document] = true
       render "documents/show"

--- a/app/controllers/document_shared_lists_controller.rb
+++ b/app/controllers/document_shared_lists_controller.rb
@@ -1,5 +1,6 @@
 class DocumentSharedListsController < ApplicationController
   def create
+    @documents = policy_scope(Document).validated
     @shared_document = SharedDocument.new
     @shared_list = SharedList.new
     @document = Document.find(params[:document_id]).decorate

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -10,6 +10,7 @@ class DocumentsController < ApplicationController
   end
 
   def index
+    @shared_document = SharedDocument.new
     @documents = policy_scope(Document).includes(attachment_attachment: :blob)
     if search_params.present?
       search_params.reject { |key, value| value.blank? || key == "title" }.each do |key, value|
@@ -28,10 +29,10 @@ class DocumentsController < ApplicationController
       @documents
     end
 
-    respond_to do |format|
-      format.html
-      format.js
-    end
+    # respond_to do |format|
+    #   format.html
+    #   format.js
+    # end
   end
 
   # TO KEEP: initial version to add folders or documents to shared list directly

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -11,7 +11,9 @@ class DocumentsController < ApplicationController
 
   def index
     @shared_document = SharedDocument.new
-    @documents = policy_scope(Document).includes(attachment_attachment: :blob)
+    @shared_list = SharedList.new
+    @document_shared_list = DocumentSharedList.new
+    @documents = policy_scope(Document).includes(:folders, attachment_attachment: :blob, document_folders: :folder)
     if search_params.present?
       search_params.reject { |key, value| value.blank? || key == "title" }.each do |key, value|
         if key == "created_at"

--- a/app/controllers/shared_documents_controller.rb
+++ b/app/controllers/shared_documents_controller.rb
@@ -4,6 +4,7 @@ class SharedDocumentsController < ApplicationController
   before_action :find_document, only: %i[create]
 
   def create
+    @documents = policy_scope(Document).validated
     @shared_list = SharedList.new
     @document_shared_list = DocumentSharedList.new
 

--- a/app/controllers/shared_documents_controller.rb
+++ b/app/controllers/shared_documents_controller.rb
@@ -20,7 +20,10 @@ class SharedDocumentsController < ApplicationController
     if @shared_document.save
       @shared_document.add_contacts!
       @shared_document.notify_contacts
-      redirect_to document_path(@document), flash: { validation_message: true, message: "Votre document a bien été envoyé." }
+      respond_to do |format|
+        format.html { redirect_to documents_path, flash: { validation_message: true, message: "Votre document a bien été envoyé." } }
+        format.js { @message = "Votre document a bien été envoyé." }
+      end
     else
       flash.now[:errors_create_shared_document] = true
       render 'documents/show'

--- a/app/controllers/shared_lists_controller.rb
+++ b/app/controllers/shared_lists_controller.rb
@@ -13,10 +13,14 @@ class SharedListsController < ApplicationController
   end
 
   def create_and_attach_document
+    @documents = policy_scope(Document).validated
     @shared_document = SharedDocument.new
     @document_shared_list = @shared_list.document_shared_lists.new(document: @document)
     if @shared_list.save
-      redirect_to document_path(@document), flash: { validation_message: true, message: "Votre liste de partage a bien été créée et votre document a bien été ajouté." }
+      respond_to do |format|
+        format.html { redirect_to document_path(@document), flash: { validation_message: true, message: "Votre liste de partage a bien été créée et votre document a bien été ajouté." } }
+        format.js { @message = "Votre liste de partage a bien été créée et votre document a bien été ajouté." }
+      end
     else
       flash.now[:errors_attach_document] = true
       render 'documents/show'

--- a/app/policies/public/shared_document_policy.rb
+++ b/app/policies/public/shared_document_policy.rb
@@ -1,5 +1,5 @@
 class Public::SharedDocumentPolicy < ApplicationPolicy
   def show?
-    record.contacts_added? && (record.validity.present? ? record.validity >= Date.today : true)
+    record.document.validated? && record.contacts_added? && (record.validity.present? ? record.validity >= Date.today : true)
   end
 end

--- a/app/views/admin/documents/add_to_folder.js.erb
+++ b/app/views/admin/documents/add_to_folder.js.erb
@@ -1,0 +1,5 @@
+$('.modal#addDocument<%=@document.id%>ToFolderOrSharedList').modal('toggle');
+$('.modal#addDocument<%=@document.id%>ToFolderOrSharedList form#edit_document_<%=@document.id%>').replaceWith("<%= j render('documents/add_to_folder_form', document: @document) %>")
+
+$('.modal#validationModal').replaceWith("<%= j render('shared/validation_modal', message: @message) %>")
+$('.modal#validationModal').modal("toggle");

--- a/app/views/document_shared_lists/create.js.erb
+++ b/app/views/document_shared_lists/create.js.erb
@@ -1,0 +1,4 @@
+$('.modal#addDocument<%=@document.id%>ToFolderOrSharedList').modal('toggle');
+
+$('.modal#validationModal').replaceWith("<%= j render('shared/validation_modal', message: @message) %>")
+$('.modal#validationModal').modal("toggle");

--- a/app/views/documents/_add_to_shared_document_modal.html.erb
+++ b/app/views/documents/_add_to_shared_document_modal.html.erb
@@ -1,9 +1,9 @@
 <!-- Modal -->
-<div class="modal fade" id="addDocumentToSharedDocument" tabindex="-1" role="dialog" aria-labelledby="addDocumentToSharedDocumentTitle" aria-hidden="true" data-target='show-modal.modalId'>
+<div class="modal fade" id="addDocumentToSharedDocument<%= document.id %>" tabindex="-1" role="dialog" aria-labelledby="addDocumentToSharedDocument<%= document.id %>Title" aria-hidden="true" data-target='show-modal.modalId'>
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-header">
-        <div class="modal-title" id="addDocumentToSharedDocumentTitle">
+        <div class="modal-title" id="addDocumentToSharedDocument<%= document.id %>Title">
           <h4 class="color-burgundy mb-0">Envoyer</h4>
           <h5 class="mb-0"><%= document.title %></h5>
           <h4 class="color-burgundy mb-0">à...</h4>

--- a/app/views/documents/_add_to_shared_list_or_folder_modal.html.erb
+++ b/app/views/documents/_add_to_shared_list_or_folder_modal.html.erb
@@ -1,9 +1,9 @@
 <!-- Modal -->
-<div class="modal fade" id="addDocumentToFolderOrSharedList" tabindex="-1" role="dialog" aria-labelledby="addDocumentToFolderOrSharedListTitle" aria-hidden="true" data-target='show-modal.modalId'>
+<div class="modal fade" id="addDocument<%=document.id%>ToFolderOrSharedList" tabindex="-1" role="dialog" aria-labelledby="addDocument<%=document.id%>ToFolderOrSharedListTitle" aria-hidden="true" data-target='show-modal.modalId'>
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-header">
-        <div class="modal-title" id="addDocumentToFolderOrSharedListTitle">
+        <div class="modal-title" id="addDocument<%=document.id%>ToFolderOrSharedListTitle">
           <h4 class="color-burgundy mb-0">Ajouter</h4>
           <h5 class="mb-0"><%= document.title %></h5>
           <h4 class="color-burgundy mb-0">à...</h4>

--- a/app/views/documents/_card.slim
+++ b/app/views/documents/_card.slim
@@ -28,6 +28,9 @@
     .card-actions
       = link_to document_path(document), class: "btn" do
         i.fa.fa-search
+      - if document.validated? && (params[:controller] == "documents" && params[:action] == "index")
+        = link_to document_path(document), data: { toggle: "modal", target: "#addDocumentToSharedDocument#{document.id}" }, class: "btn" do
+          i.far.fa-paper-plane
 
 //div
   - case document.format

--- a/app/views/documents/_card.slim
+++ b/app/views/documents/_card.slim
@@ -28,9 +28,11 @@
     .card-actions
       = link_to document_path(document), class: "btn" do
         i.fa.fa-search
-      - if document.validated? && (params[:controller] == "documents" && params[:action] == "index")
+      - if document.validated? && ((params[:controller] == "documents" && params[:action] == "index") || (params[:controller] == "shared_lists" && params[:action] == "create_and_attach_document") || (params[:controller] == "shared_documents" && params[:action] == "create") || (params[:controller] == "document_shared_lists" && params[:action] == "create") || (params[:controller] == "documents" && params[:action] == "add_to_folder"))
         = link_to document_path(document), data: { toggle: "modal", target: "#addDocumentToSharedDocument#{document.id}" }, class: "btn" do
           i.far.fa-paper-plane
+        = link_to document_path(document), data: { toggle: "modal", target: "#addDocument#{document.id}ToFolderOrSharedList" }, class: "btn" do
+          i.fas.fa-plus
 
 //div
   - case document.format

--- a/app/views/documents/_list.html.erb
+++ b/app/views/documents/_list.html.erb
@@ -10,6 +10,10 @@
     <% end %>
     <% documents.each do |document| %>
       <%= render 'card', document: document.decorate %>
+
+      <% if document.validated? %>
+        <%= render 'documents/add_to_shared_document_modal', document: document, shared_document: @shared_document %>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/documents/_list.html.erb
+++ b/app/views/documents/_list.html.erb
@@ -14,6 +14,8 @@
       <% if document.validated? %>
         <%= render 'documents/add_to_shared_document_modal', document: document, shared_document: @shared_document %>
       <% end %>
+      <%= render 'documents/add_to_shared_list_or_folder_modal', document: document, shared_list: @shared_list, document_shared_list: @document_shared_list %>
+      <%= render 'documents/add_to_shared_document_modal', document: document, shared_document: @shared_document %>
     <% end %>
   </div>
 </div>

--- a/app/views/documents/_show_content.slim
+++ b/app/views/documents/_show_content.slim
@@ -51,7 +51,7 @@
       = link_to rails_blob_path(document.attachment, disposition: "attachment"), class: "btn" do
         i.fas.fa-file-download
       - if document.validated?
-        a.btn data-toggle="modal" data-target="#addDocumentToSharedDocument"
+        a.btn data-toggle="modal" data-target="#addDocumentToSharedDocument#{document.id}"
           i.far.fa-paper-plane
         a.btn data-toggle="modal" data-target="#addDocumentToFolderOrSharedList"
           i.fas.fa-plus

--- a/app/views/documents/_show_content.slim
+++ b/app/views/documents/_show_content.slim
@@ -53,5 +53,5 @@
       - if document.validated?
         a.btn data-toggle="modal" data-target="#addDocumentToSharedDocument#{document.id}"
           i.far.fa-paper-plane
-        a.btn data-toggle="modal" data-target="#addDocumentToFolderOrSharedList"
+        a.btn data-toggle="modal" data-target="#addDocument#{document.id}ToFolderOrSharedList"
           i.fas.fa-plus

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -2,3 +2,5 @@
   <%= render 'search_form' %>
   <%= render 'list', documents: @documents %>
 </div>
+
+<%= render 'shared/validation_modal', message: "" %>

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -4,3 +4,5 @@
 
 <%= render 'documents/add_to_shared_list_or_folder_modal', document: @document, shared_list: @shared_list, document_shared_list: @document_shared_list %>
 <%= render 'documents/add_to_shared_document_modal', document: @document, shared_document: @shared_document %>
+
+<%= render 'shared/validation_modal', message: "" %>

--- a/app/views/documents/show.js.erb
+++ b/app/views/documents/show.js.erb
@@ -7,6 +7,6 @@ $('.modal#addDocumentToFolderOrSharedList').on('hidden.bs.modal', event => {
   $("form#new_shared_list").replaceWith("<%= j render('shared_lists/create_and_attach_document_form', document: @document, shared_list: SharedList.new) %>");
 })
 
-$('.modal#addDocumentToSharedDocument').on('hidden.bs.modal', event => {
+$('.modal#addDocumentToSharedDocument<%= @document.id %>').on('hidden.bs.modal', event => {
   $("#new_shared_document").replaceWith("<%= j render('shared_documents/form', document: @document, shared_document: SharedDocument.new) %>");
 })

--- a/app/views/documents/show.js.erb
+++ b/app/views/documents/show.js.erb
@@ -2,7 +2,7 @@ $("form#new_document_shared_list").replaceWith("<%= j render('document_shared_li
 $("form#new_shared_list").replaceWith("<%= j render('shared_lists/create_and_attach_document_form', document: @document, shared_list: @shared_list) %>");
 $("form#new_shared_document").replaceWith("<%= j render('shared_documents/form', document: @document, shared_document: @shared_document) %>");
 
-$('.modal#addDocumentToFolderOrSharedList').on('hidden.bs.modal', event => {
+$('.modal#addDocument<%=@document.id%>ToFolderOrSharedList').on('hidden.bs.modal', event => {
   $("form#new_document_shared_list").replaceWith("<%= j render('document_shared_lists/form', document: @document, document_shared_list: @document.document_shared_lists.new) %>");
   $("form#new_shared_list").replaceWith("<%= j render('shared_lists/create_and_attach_document_form', document: @document, shared_list: SharedList.new) %>");
 })

--- a/app/views/documents/show.js.erb
+++ b/app/views/documents/show.js.erb
@@ -12,3 +12,11 @@ $('.modal#addDocumentToSharedDocument<%= @document.id %>').on('hidden.bs.modal',
     $('.modal#addDocumentToSharedDocument<%= document.id %> form#new_shared_document').replaceWith("<%= j render('shared_documents/form', document: document, shared_document: SharedDocument.new) %>")
   <% end %>
 })
+
+// $('.modal#addDocument<%= @document.id %>ToFolderOrSharedList').on('hidden.bs.modal', event => {
+//   <% @documents.each do |document| %>
+//     $('.modal#addDocument<%= document.id %>ToFolderOrSharedList form#new_document_shared_list').replaceWith("<%= j render('document_shared_lists/form', document: document, document_shared_list: DocumentSharedList.new) %>");
+//     $('.modal#addDocument<%= document.id %>ToFolderOrSharedList form#new_shared_list').replaceWith("<%= j render('shared_lists/create_and_attach_document_form', document: document, shared_list: SharedList.new) %>");
+//     $('.modal#addDocument<%= document.id %>ToFolderOrSharedList form#edit_document_<%= document.id %>').replaceWith("<%= j render('documents/add_to_folder_form', document: document) %>");
+//   <% end %>
+// })

--- a/app/views/documents/show.js.erb
+++ b/app/views/documents/show.js.erb
@@ -8,5 +8,7 @@ $('.modal#addDocumentToFolderOrSharedList').on('hidden.bs.modal', event => {
 })
 
 $('.modal#addDocumentToSharedDocument<%= @document.id %>').on('hidden.bs.modal', event => {
-  $("#new_shared_document").replaceWith("<%= j render('shared_documents/form', document: @document, shared_document: SharedDocument.new) %>");
+  <% @documents.each do |document| %>
+    $('.modal#addDocumentToSharedDocument<%= document.id %> form#new_shared_document').replaceWith("<%= j render('shared_documents/form', document: document, shared_document: SharedDocument.new) %>")
+  <% end %>
 })

--- a/app/views/shared_documents/create.js.erb
+++ b/app/views/shared_documents/create.js.erb
@@ -1,0 +1,5 @@
+$('.modal#addDocumentToSharedDocument<%=@document.id%>').modal('toggle');
+$('.modal#addDocumentToSharedDocument<%=@document.id%> form#new_shared_document').replaceWith("<%= j render('shared_documents/form', document: @document, shared_document: SharedDocument.new) %>")
+
+$('.modal#validationModal').replaceWith("<%= j render('shared/validation_modal', message: @message) %>")
+$('.modal#validationModal').modal("toggle");

--- a/app/views/shared_lists/create_and_attach_document.js.erb
+++ b/app/views/shared_lists/create_and_attach_document.js.erb
@@ -1,0 +1,6 @@
+$('.modal#addDocument<%=@document.id%>ToFolderOrSharedList').modal('toggle');
+
+$('.modal#validationModal').replaceWith("<%= j render('shared/validation_modal', message: @message) %>")
+$('.modal#validationModal').modal("toggle");
+
+$('#shared-list-nav-item a').attr("href", "<%=shared_list_path(current_user.shared_lists.initial.first)%>")

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,4 +1,5 @@
 Rails.application.configure do
+  config.action_mailer.asset_host = 'http://localhost:3000'
   # config.action_mailer.default_url_options = { host: "http://localhost:3000" }
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
   config.action_mailer.delivery_method = :letter_opener

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,4 +1,5 @@
 Rails.application.configure do
+  config.action_mailer.asset_host = 'https://gilead-media.herokuapp.com/'
   config.action_mailer.default_url_options = { host: "gilead-media.herokuapp.com" }
   config.action_mailer.delivery_method = :postmark
   config.action_mailer.postmark_settings = {

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -1,4 +1,5 @@
 Rails.application.configure do
+  config.action_mailer.asset_host = 'https://gilead-media-staging.herokuapp.com/'
   config.action_mailer.default_url_options = { host: "gilead-media-staging.herokuapp.com" }
   config.action_mailer.delivery_method = :postmark
   config.action_mailer.postmark_settings = {


### PR DESCRIPTION
- modify modal id addDocumentToSharedDocument to addDocumentToSharedDocument#{document.id}
- update Public::SharedDocumentPolicy show?
- ajax on shared_documents / create
- css on btn:focus
- add action addDocumentToSharedDocument on documents index
- rename modal id addDocumentToFolderOrSharedList in addDocument<%=@document.id%>ToFolderOrSharedList
- add validation message on documents/show to be rendered in js
- add ajax on documents action add_to_folder
- add ajax on document_shared_lists create
- add ajax shared_lists create_and_attach_document
- add config.action_mailer.asset_host in environments files
- add link to add document to folder or to shared list on documents index