### PR TITLE
Shared folder pipeline

### DIFF
--- a/app/controllers/shared_folders_controller.rb
+++ b/app/controllers/shared_folders_controller.rb
@@ -1,7 +1,12 @@
 class SharedFoldersController < ApplicationController
   include ListHelper
 
-  before_action :find_folder, only: %i[create]
+  before_action :find_folder, only: %i[new create]
+
+  def new
+    @shared_folder = @folder.shared_folders.new
+    authorize @shared_folder
+  end
 
   def create
     @folders = policy_scope(Folder)
@@ -22,19 +27,18 @@ class SharedFoldersController < ApplicationController
       @shared_folder.add_contacts!
       @shared_folder.notify_contacts
       respond_to do |format|
-        format.html { redirect_to folders_path, flash: { validation_message: true, message: "Votre dossier a bien été envoyé." } }
+        format.html { redirect_to folder_path(@folder), flash: { validation_message: true, message: "Votre dossier a bien été envoyé." } }
         format.js { @message = "Votre dossier a bien été envoyé." }
       end
     else
-      flash.now[:errors_create_shared_folder] = true
-      render 'folders/index'
+      render :new
     end
   end
 
   private
 
   def find_folder
-    @folder = Folder.find(params[:folder_id])
+    @folder = Folder.find(params[:id])
   end
 
   def shared_folder_params

--- a/app/models/folder.rb
+++ b/app/models/folder.rb
@@ -3,6 +3,7 @@ class Folder < ApplicationRecord
   has_many :documents, through: :document_folders
   has_many :folder_shared_lists, dependent: :destroy
   has_many :shared_lists, through: :folder_shared_lists
+  has_many :shared_folders, dependent: :destroy
 
   validates :title, presence: true, uniqueness: true
 

--- a/app/policies/shared_folder_policy.rb
+++ b/app/policies/shared_folder_policy.rb
@@ -1,4 +1,8 @@
 class SharedFolderPolicy < ApplicationPolicy
+  def new?
+    create?
+  end
+
   def create?
     true
   end

--- a/app/views/folders/_add_to_shared_folder_modal.html.erb
+++ b/app/views/folders/_add_to_shared_folder_modal.html.erb
@@ -1,9 +1,9 @@
 <!-- Modal -->
-<div class="modal fade" id="addFolderToSharedFolder<%= folder.id %>" tabindex="-1" role="dialog" aria-labelledby="addFolderToSharedFolder<%= folder.id %>Title" aria-hidden="true" data-target='show-modal.modalId'>
+<div class="modal fade" id="addFolderToSharedFolder" tabindex="-1" role="dialog" aria-labelledby="addFolderToSharedFolderTitle" aria-hidden="true" data-target='show-modal.modalId'>
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-header" style="border-bottom: 1px solid #dee2e6;">
-        <div class="modal-title" id="addFolderToSharedFolder<%= folder.id %>Title">
+        <div class="modal-title" id="addFolderToSharedFolderTitle">
           <h4 class="color-burgundy mb-0">Envoyer</h4>
           <h5 class="mb-0"><%= folder.title %></h5>
           <h4 class="color-burgundy mb-0">à...</h4>

--- a/app/views/folders/_card.slim
+++ b/app/views/folders/_card.slim
@@ -15,7 +15,7 @@
       = link_to download_folder_path(folder), method: :patch, class: "btn" do
         i.fas.fa-file-download
       - if (params[:controller] == "folders" && params[:action] == "index") || (params[:controller] == "shared_lists" && params[:action] == "create_and_attach_folder") || (params[:controller] == "shared_folders" && params[:action] == "create") || (params[:controller] == "folder_shared_lists" && params[:action] == "create")
-        = link_to folder_path(folder), data: { toggle: "modal", target: "#addFolderToSharedFolder" }, class: "btn" do
+        = link_to new_shared_folder_path(folder), class: "btn", data: { toggle: "modal", target: "#addFolderToSharedFolder" }, remote: true do
           i.far.fa-paper-plane
         = link_to folder_path(folder), data: { toggle: "modal", target: "#addFolder#{folder.id}ToSharedList" }, class: "btn" do
           i.fas.fa-plus

--- a/app/views/folders/_card.slim
+++ b/app/views/folders/_card.slim
@@ -15,7 +15,7 @@
       = link_to download_folder_path(folder), method: :patch, class: "btn" do
         i.fas.fa-file-download
       - if (params[:controller] == "folders" && params[:action] == "index") || (params[:controller] == "shared_lists" && params[:action] == "create_and_attach_folder") || (params[:controller] == "shared_folders" && params[:action] == "create") || (params[:controller] == "folder_shared_lists" && params[:action] == "create")
-        = link_to folder_path(folder), data: { toggle: "modal", target: "#addFolderToSharedFolder#{folder.id}" }, class: "btn" do
+        = link_to folder_path(folder), data: { toggle: "modal", target: "#addFolderToSharedFolder" }, class: "btn" do
           i.far.fa-paper-plane
         = link_to folder_path(folder), data: { toggle: "modal", target: "#addFolder#{folder.id}ToSharedList" }, class: "btn" do
           i.fas.fa-plus

--- a/app/views/folders/index.html.erb
+++ b/app/views/folders/index.html.erb
@@ -3,9 +3,9 @@
     <% @folders.each do |folder| %>
       <%= render 'folders/card', folder: folder %>
       <%= render 'folders/add_to_shared_list_modal', folder: folder, shared_list: @shared_list, folder_shared_list: @folder_shared_list %>
-      <%= render 'folders/add_to_shared_folder_modal', folder: folder, shared_folder: @shared_folder %>
     <% end %>
   </div>
 </div>
 
+<%= render 'folders/add_to_shared_folder_modal', folder: @folders.first, shared_folder: @shared_folder %>
 <%= render 'shared/validation_modal', message: "" %>

--- a/app/views/folders/show.slim
+++ b/app/views/folders/show.slim
@@ -7,7 +7,7 @@
           i.btn.fa.fa-minus.h-100.pt-2
       = link_to download_folder_path(@folder), method: :patch, class: "btn" do
         i.fas.fa-file-download
-      = link_to folder_path(@folder), data: { toggle: "modal", target: "#addFolderToSharedFolder" }, class: "btn" do
+      = link_to new_shared_folder_path(@folder), class: "btn", data: { toggle: "modal", target: "#addFolderToSharedFolder" }, remote: true do
         i.far.fa-paper-plane
       = link_to folder_path(@folder), data: { toggle: "modal", target: "#addFolder#{@folder.id}ToSharedList" }, class: "btn" do
         i.fas.fa-plus

--- a/app/views/folders/show.slim
+++ b/app/views/folders/show.slim
@@ -7,7 +7,7 @@
           i.btn.fa.fa-minus.h-100.pt-2
       = link_to download_folder_path(@folder), method: :patch, class: "btn" do
         i.fas.fa-file-download
-      = link_to folder_path(@folder), data: { toggle: "modal", target: "#addFolderToSharedFolder#{@folder.id}" }, class: "btn" do
+      = link_to folder_path(@folder), data: { toggle: "modal", target: "#addFolderToSharedFolder" }, class: "btn" do
         i.far.fa-paper-plane
       = link_to folder_path(@folder), data: { toggle: "modal", target: "#addFolder#{@folder.id}ToSharedList" }, class: "btn" do
         i.fas.fa-plus

--- a/app/views/shared_folders/_form.slim
+++ b/app/views/shared_folders/_form.slim
@@ -1,4 +1,4 @@
-= simple_form_for [folder, shared_folder], data: { controller: "flatpickr" }, html: { class: "label-input-in-line-equal-space" }, remote: true do |f|
+= simple_form_for [folder, shared_folder], url: shared_folders_path(folder), method: :post, data: { controller: "flatpickr" }, html: { class: "label-input-in-line-equal-space" }, remote: true do |f|
   = f.input :validity, as: :string, placeholder: "Date", input_html: { data: { target: "flatpickr.dateSelection" } }
   = f.input :download, as: :select, prompt: "Sélectionnez"
   = f.association :contacts do |c|

--- a/app/views/shared_folders/create.js.erb
+++ b/app/views/shared_folders/create.js.erb
@@ -1,5 +1,3 @@
-$('.modal#addFolderToSharedFolder<%=@folder.id%>').modal('toggle');
-$('.modal#addFolderToSharedFolder<%=@folder.id%> form#new_shared_folder').replaceWith("<%= j render('shared_folders/form', folder: @folder, shared_folder: SharedFolder.new) %>")
-
+$(".modal#addFolderToSharedFolder").modal("hide")
 $('.modal#validationModal').replaceWith("<%= j render('shared/validation_modal', message: @message) %>")
-$('.modal#validationModal').modal("toggle");
+$('.modal#validationModal').modal("show")

--- a/app/views/shared_folders/new.html.erb
+++ b/app/views/shared_folders/new.html.erb
@@ -1,0 +1,6 @@
+<div class="container container-content">
+  <h1>Envoyer le dossier</h1>
+  <%= render 'form', folder: @folder, shared_folder: @shared_folder %>
+</div>
+
+<%= render 'shared/validation_modal', message: "" %>

--- a/app/views/shared_folders/new.js.erb
+++ b/app/views/shared_folders/new.js.erb
@@ -1,0 +1,2 @@
+$(".modal#addFolderToSharedFolder .modal-header h5").replaceWith("<h5><%= @folder.title %></h5>");
+$("form#new_shared_folder").replaceWith("<%= j render('shared_folders/form', folder: @folder, shared_folder: @shared_folder) %>");

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,7 +30,9 @@ Rails.application.routes.draw do
       post :create_and_attach_folder, on: :collection
     end
     resources :folder_shared_lists, only: %i[create]
-    resources :shared_folders, only: %i[create]
+    member do
+      resources :shared_folders, only: %i[new create]
+    end
   end
   resources :shared_lists, only: %i[index show] do
     patch :add_contacts, on: :member


### PR DESCRIPTION
- add has_many :shared_folders, dependent: :destroy in folder model because missing
- rename modal id #addFolderToSharedFolder#{@folder.id} in #addFolderToSharedFolder
- render only once in folders/index.html.erb the add_to_shared_folder_modal
- change link_to folder_path(@folder) in link_to new_shared_folder_path(@folder) in views
- add/update routes policy views for shared_folders